### PR TITLE
Rename V-web, add V-core-plans

### DIFF
--- a/hab-core/config.toml
+++ b/hab-core/config.toml
@@ -195,5 +195,9 @@ name = "V-sup"
 color = "0fb0bf"
 
 [[label]]
-name = "V-web"
+name = "V-front-end"
+color = "0fb0bf"
+
+[[label]]
+name = "V-core-plans"
 color = "0fb0bf"


### PR DESCRIPTION
I recently did this by hand (sorry!) so I’m submitting this PR to make it right.

Signed-off-by: Christian Nunciato <chris@nunciato.org>