### PR TITLE
Add "Documentation" label back for the docs team

### DIFF
--- a/hab-core/config.toml
+++ b/hab-core/config.toml
@@ -103,6 +103,15 @@ name = "Source: External"
 color = "0fb0bf"
 description = "Issues raised by non-Chef employees"
 
+# Other
+########################################################################
+
+[[label]]
+name = "Documentation"
+color = "000000"
+description = "Flags an issue / PR for attention by the technical documentation team"
+mappings = [ "A-documentation" ]
+
 ########################################################################
 # OLD LABELS
 ########################################################################
@@ -121,8 +130,7 @@ delete = true
 
 [[label]]
 name = "A-documentation"
-color = "87B09A"
-mappings = [ "Documentation" ]
+delete = true
 
 [[label]]
 name = "A-cli"


### PR DESCRIPTION
This was recently accidentally converted back to the old
"A-documentation" label.

That is now fixed, and the old label is removed.

Signed-off-by: Christopher Maier <cmaier@chef.io>